### PR TITLE
Several improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,12 +13,14 @@ PostgreSQL versions that the SPEC can support
 ---------------------------------------------
 * 9.3 >= 9.3.4 (EoL and not maintained by tds_fdw upstream anymore)
 * 9.4 >= 9.4.1 (EoL and not maintained by tds_fdw upstream anymore)
-* 9.5 >= 9.5.1
-* 9.6 >= 9.6.1
+* 9.5 >= 9.5.1 (EoL and not maintained by tds_fdw upstream anymore)
+* 9.6 >= 9.6.1 (EoL and not maintained by tds_fdw upstream anymore)
 * 10 >= 10.0
 * 11 >= 11.0
 * 12 >= 12.0
 * 13 >= 13.0
+* 14 >= 14.0
+* 15 >= 15.0
 
 Requirements
 ------------
@@ -35,7 +37,7 @@ And:
 
 * postgresql[version]-devel
 
-Being **[version]** one of: 93, 94, 95, 96, 10, 11, 12 or 13
+Being **[version]** one of: 93, 94, 95, 96, 10, 11, 12, 13, 14 or 15
 
 To install the RPM for PostgreSQL
 
@@ -46,7 +48,7 @@ And:
 * postgresql[version]-server
 * postgresql[version]-libs
 
-Being **[version]** one of: 93, 94, 95, 96, 10, 11, 12 or 13
+Being **[version]** one of: 93, 94, 95, 96, 10, 11, 12, 13, 14 or 15
 
 Building fresh RPMs
 -------------------
@@ -64,10 +66,10 @@ Build the RPMs for with:
 
     ./tds-fdw_rpm -p [version]
 
-Where `[version]` is one of: 9.3, 9.4, 9.5, 9.6, 10, 11, 12 or 13
+Where `[version]` is one of: 9.3, 9.4, 9.5, 9.6, 10, 11, 12, 13, 14 or 15
 
 And install with
 
     rpm -Uvh RPMS/$HOSTTYPE/postgresql-[version]-tds_fdw-*.*.$HOSTTYPE.rpm
 
-Where `[version]` is one of: 9.3, 9.4, 9.5, 9.6, 10, 11, 12 or 13
+Where `[version]` is one of: 9.3, 9.4, 9.5, 9.6, 10, 11, 12, 13, 14 or 15

--- a/README.opensuse.md
+++ b/README.opensuse.md
@@ -12,8 +12,8 @@ cat /etc/os-release
 
 Finally run the following commands, after adapting `PGVER`, `LEAPVER` and `BRANCH`as needed.
 ```
-PGVER=12
-LEAPVER=15.1
+PGVER=15
+LEAPVER=15.4
 BRANCH=master
 PGSVER=$(echo $PGVER|sed -e 's/\.//g')
 zypper ar http://download.opensuse.org/repositories/server:/database:/postgresql/openSUSE_Leap_${LEAPVER}/server:database:postgresql.repo

--- a/ci
+++ b/ci
@@ -6,13 +6,16 @@ LANG=en_EN
 SCRIPT=$(basename ${0})
 
 # Supported distributions
-SUPPORTEDDISTROS='centos6 centos7'
+SUPPORTEDDISTROS='centos6 centos7 rockylinux8'
 
 # Supported PostgreSQL major versions
-POSTGRESQLMAJORVERS='9.3 9.4 9.5 9.6 10 11 12 13'
+POSTGRESQLMAJORVERS='9.3 9.4 9.5 9.6 10 11 12 13 14 15'
 
 # Allocate tty by default
 TTY='-t'
+
+# Use docker by default
+DOCKER='docker'
 
 print_info() {
   echo -e "\033[1;36m[INFO] ${1}\033[0m"
@@ -56,6 +59,7 @@ print_help() {
   echo "  --name=<CONTAINER_NAME> Define the container name"
   echo "                          If undefined, container name will be"
   echo "                          s3fs-fuse-rpm-<DISTRO>-<TIMESTAMP>"
+  echo "  --podman          If present, use podman instead of docker"
   echo "  --remove-on-error If present, remove the container on errors"
   echo "  --notty           If present, does not allocate a tty for docker"
   echo "  --nocleanup       If present, do not run the cleanup script before exiting"
@@ -63,7 +67,7 @@ print_help() {
 }
 
 remove_container() {
-  docker container rm -f ${1}
+  ${DOCKER} container rm -f ${1}
 }
 
 exit_error() {
@@ -80,7 +84,7 @@ docker_run() {
   if [ ! -z ${3} ]; then
     local COMMAND_USER="-u ${3}"
   fi
-  local COMMAND="docker container exec -i ${TTY} ${COMMAND_USER} ${1} ${2}"
+  local COMMAND="${DOCKER} container exec -i ${TTY} ${COMMAND_USER} ${1} ${2}"
   local RESULT=$(${COMMAND})
   exit_error ${?}
   if [ "${RESULT}" != "" ]; then
@@ -101,7 +105,7 @@ check_pgver() {
 }
 
 # read the options
-ARGS=$(getopt -o h --long help,remove-on-error,notty,nocleanup,distro:,postgresql-major-ver:,name: -n "${SCRIPT}" -- "$@")
+ARGS=$(getopt -o h --long help,podman,remove-on-error,notty,nocleanup,distro:,postgresql-major-ver:,name: -n "${SCRIPT}" -- "$@")
 if [ $? -ne 0 ];
 then
   print_incorrect_syntax
@@ -113,6 +117,7 @@ eval set -- "${ARGS}"
 while true ; do
   case "${1}" in
     -h|--help)         print_help "${SUPPORTEDDISTROS}" "${POSTGRESQLMAJORVERS}"; exit 1;;
+    --podman)          DOCKER="podman"; shift 1 ;;
     --remove-on-error) REMOVE_ON_ERROR="--rm"; shift 1 ;;
     --notty)           TTY=""; shift 1 ;;
     --nocleanup)       NOCLEANUP="TRUE"; shift ;;
@@ -128,6 +133,7 @@ done
 case "${DISTRO}" in
   centos6)       DOCKER_IMAGE="tdsfdw/centos6-postgresql:${POSTGRESQLMAJORVER}";;
   centos7)       DOCKER_IMAGE="tdsfdw/centos7-postgresql:${POSTGRESQLMAJORVER}";;
+  rockylinux8)   DOCKER_IMAGE="tdsfdw/rockylinux8-postgresql:${POSTGRESQLMAJORVER}";;
   *)             print_error_unsupported_distro
                  exit 1;;
 esac
@@ -149,9 +155,9 @@ fi
 PACKAGE_NAME="postgresql-${SHORTVER}-tds_fdw"
 
 print_info "Pulling latest image..."
-docker pull ${DOCKER_IMAGE}
+${DOCKER} pull ${DOCKER_IMAGE}
 print_info "Starting container ${CONTAINER_NAME}..."
-docker container run -i ${TTY} ${REMOVE_ON_ERROR} --name "${CONTAINER_NAME}" -v ${PWD}:/tmp/tds_fdw-rpms -w /tmp/tds_fdw-rpms -d ${DOCKER_IMAGE}
+${DOCKER} container run -i ${TTY} ${REMOVE_ON_ERROR} --name "${CONTAINER_NAME}" -v ${PWD}:/tmp/tds_fdw-rpms -w /tmp/tds_fdw-rpms -d ${DOCKER_IMAGE}
 print_info "Cleaning up"
 docker_run "${CONTAINER_NAME}" "./clean" "postgres"
 print_info "Building tds_fdw package..."

--- a/tds_fdw-rpm
+++ b/tds_fdw-rpm
@@ -1,7 +1,7 @@
 #!/bin/bash -e
 
 SCRIPT=$(basename ${0})
-VERSIONS="9.3 9.4 9.5 9.6 10 11 12 13"
+VERSIONS="9.3 9.4 9.5 9.6 10 11 12 13 14 15"
 
 function help() {
   echo ""
@@ -51,7 +51,6 @@ function get_sources() {
 get_url_source_from_spec() {
   local VERSION=$(sed -rn 's/Version:\s*(.*)/\1/p' ${1})
   local URL=$(sed -rn 's/Source:\s*(.*)/\1/p' ${1})
-  echo "$VERSION $URL" >la
   echo $(echo ${URL}|sed -e "s/%{version}/${VERSION}/g")
 }
 


### PR DESCRIPTION
- Enable PostgreSQL 14 and 15 for CI and building
- Enable RockyLinux8 for CI
- Allow podman instead of Docker, for CI

After this PR, the following OS and PostgreSQL versions should still work, but won't be tested:

- CentOS6
- PostgreSQL 9.3, 9.4, 9.5