### PR TITLE
Bump to tds_fdw 2.0.5, add PostgreSQL 17 and 18, EoL PosgreSQL 12

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,17 +11,19 @@ It does not yet support write operations, as added in PostgreSQL 9.3.
 
 PostgreSQL versions that the SPEC can support
 ---------------------------------------------
-* 9.3 >= 9.3.4 (EoL and not maintained by tds_fdw upstream anymore)
-* 9.4 >= 9.4.1 (EoL and not maintained by tds_fdw upstream anymore)
-* 9.5 >= 9.5.1 (EoL and not maintained by tds_fdw upstream anymore)
-* 9.6 >= 9.6.1 (EoL and not maintained by tds_fdw upstream anymore)
-* 10 >= 10.0 (EoL and not maintained by tds_fdw upstream anymore)
-* 11 >= 11.0 (EoL and not maintained by tds_fdw upstream anymore)
-* 12 >= 12.0
+* 9.3 >= 9.3.4 (EoL and not maintained by tds_fdw upstream anymore, but it should still work)
+* 9.4 >= 9.4.1 (EoL and not maintained by tds_fdw upstream anymore, but it should still work)
+* 9.5 >= 9.5.1 (EoL and not maintained by tds_fdw upstream anymore, but it should still work)
+* 9.6 >= 9.6.1 (EoL and not maintained by tds_fdw upstream anymore, but it should still work)
+* 10 >= 10.0 (EoL and not maintained by tds_fdw upstream anymore, but it should still work)
+* 11 >= 11.0 (EoL and not maintained by tds_fdw upstream anymore, but it should still work)
+* 12 >= 12.0 (EoL and not maintained by tds_fdw upstream anymore, but it should still work)
 * 13 >= 13.0
 * 14 >= 14.0
 * 15 >= 15.0
 * 16 >= 16.0
+* 17 >= 17.0
+* 18 >= 17.0
 
 Requirements
 ------------
@@ -38,7 +40,7 @@ And:
 
 * postgresql[version]-devel
 
-Being **[version]** one of: 93, 94, 95, 96, 10, 11, 12, 13, 14, 15, or 16
+Being **[version]** one of: 93, 94, 95, 96, 10, 11, 12, 13, 14, 15, 16, 17, 18
 
 To install the RPM for PostgreSQL
 
@@ -49,7 +51,7 @@ And:
 * postgresql[version]-server
 * postgresql[version]-libs
 
-Being **[version]** one of: 93, 94, 95, 96, 10, 11, 12, 13, 14, 15 or 16
+Being **[version]** one of: 93, 94, 95, 96, 10, 11, 12, 13, 14, 15, 16, 17, 18
 
 Building fresh RPMs
 -------------------
@@ -67,10 +69,10 @@ Build the RPMs for with:
 
     ./tds-fdw_rpm -p [version]
 
-Where `[version]` is one of: 9.3, 9.4, 9.5, 9.6, 10, 11, 12, 13, 14, 15, or 16
+Where `[version]` is one of: 9.3, 9.4, 9.5, 9.6, 10, 11, 12, 13, 14, 15, 16, 17, 18
 
 And install with
 
     rpm -Uvh RPMS/$HOSTTYPE/postgresql-[version]-tds_fdw-*.*.$HOSTTYPE.rpm
 
-Where `[version]` is one of: 9.3, 9.4, 9.5, 9.6, 10, 11, 12, 13, 14, 15, or 16
+Where `[version]` is one of: 9.3, 9.4, 9.5, 9.6, 10, 11, 12, 13, 14, 15, 16, 17, 18

--- a/SPECS/tds_fdw-10.spec
+++ b/SPECS/tds_fdw-10.spec
@@ -61,7 +61,7 @@ mv %{buildroot}%{PG_DOC}/README.tds_fdw.md %{buildroot}%{MOD_DOC}/README.md
 %attr(755, root, root)%{PG_LIB}/tds_fdw.so
 %dir %attr(755, root, root)%{PG_DATA}
 %dir %attr(755, root, root)%{PG_DATA}/extension
-%attr(644, root, root)%{PG_DATA}/extension/tds_fdw--%{version}.sql
+%attr(644, root, root)%{PG_DATA}/extension/tds_fdw-*.sql
 %attr(644, root, root)%{PG_DATA}/extension/tds_fdw.control
 %dir %attr(755, root, root)%{MOD_DOC}
 %doc %{MOD_DOC}/README.md

--- a/SPECS/tds_fdw-10.spec
+++ b/SPECS/tds_fdw-10.spec
@@ -2,7 +2,7 @@
 %define PG_SVER 10
 
 Name:           postgresql-%{PG_SVER}-tds_fdw
-Version:        2.0.3
+Version:        2.0.5
 Release:        0%{?dist}
 Summary:        TDS foreing data wrapper for PostgreSQL %{PG_VER}
 License:        None
@@ -67,6 +67,9 @@ mv %{buildroot}%{PG_DOC}/README.tds_fdw.md %{buildroot}%{MOD_DOC}/README.md
 %doc %{MOD_DOC}/README.md
 
 %changelog
+* Thu Oct 16 2025 Julio González Gil <packages@juliogonzalez.es> 2.0.5-0
+- 2.0.5 from https://github.com/tds-fdw/tds_fdw
+
 * Mon Oct 31 2022 Julio Gonzalez Gil <packages@juliogonzalez.es> 2.0.3-0
 - 2.0.3 from https://github.com/tds-fdw/tds_fdw
 

--- a/SPECS/tds_fdw-11.spec
+++ b/SPECS/tds_fdw-11.spec
@@ -2,7 +2,7 @@
 %define PG_SVER 11
 
 Name:           postgresql-%{PG_SVER}-tds_fdw
-Version:        2.0.3
+Version:        2.0.5
 Release:        0%{?dist}
 Summary:        TDS foreing data wrapper for PostgreSQL %{PG_VER}
 License:        None
@@ -83,6 +83,9 @@ mv %{buildroot}%{PG_DOC}/README.tds_fdw.md %{buildroot}%{MOD_DOC}/README.md
 %endif
 
 %changelog
+* Thu Oct 16 2025 Julio González Gil <packages@juliogonzalez.es> 2.0.5-0
+- 2.0.5 from https://github.com/tds-fdw/tds_fdw
+
 * Mon Oct 31 2022 Julio Gonzalez Gil <packages@juliogonzalez.es> 2.0.3-0
 - 2.0.3 from https://github.com/tds-fdw/tds_fdw
 

--- a/SPECS/tds_fdw-11.spec
+++ b/SPECS/tds_fdw-11.spec
@@ -71,7 +71,7 @@ mv %{buildroot}%{PG_DOC}/README.tds_fdw.md %{buildroot}%{MOD_DOC}/README.md
 %attr(755, root, root)%{PG_LIB}/tds_fdw.so
 %dir %attr(755, root, root)%{PG_DATA}
 %dir %attr(755, root, root)%{PG_DATA}/extension
-%attr(644, root, root)%{PG_DATA}/extension/tds_fdw--%{version}.sql
+%attr(644, root, root)%{PG_DATA}/extension/tds_fdw-*.sql
 %attr(644, root, root)%{PG_DATA}/extension/tds_fdw.control
 %dir %attr(755, root, root)%{MOD_DOC}
 %doc %{MOD_DOC}/README.md

--- a/SPECS/tds_fdw-12.spec
+++ b/SPECS/tds_fdw-12.spec
@@ -71,7 +71,7 @@ mv %{buildroot}%{PG_DOC}/README.tds_fdw.md %{buildroot}%{MOD_DOC}/README.md
 %attr(755, root, root)%{PG_LIB}/tds_fdw.so
 %dir %attr(755, root, root)%{PG_DATA}
 %dir %attr(755, root, root)%{PG_DATA}/extension
-%attr(644, root, root)%{PG_DATA}/extension/tds_fdw--%{version}.sql
+%attr(644, root, root)%{PG_DATA}/extension/tds_fdw-*.sql
 %attr(644, root, root)%{PG_DATA}/extension/tds_fdw.control
 %dir %attr(755, root, root)%{MOD_DOC}
 %doc %{MOD_DOC}/README.md

--- a/SPECS/tds_fdw-12.spec
+++ b/SPECS/tds_fdw-12.spec
@@ -2,7 +2,7 @@
 %define PG_SVER 12
 
 Name:           postgresql-%{PG_SVER}-tds_fdw
-Version:        2.0.3
+Version:        2.0.5
 Release:        0%{?dist}
 Summary:        TDS foreing data wrapper for PostgreSQL %{PG_VER}
 License:        None
@@ -83,6 +83,9 @@ mv %{buildroot}%{PG_DOC}/README.tds_fdw.md %{buildroot}%{MOD_DOC}/README.md
 %endif
 
 %changelog
+* Thu Oct 16 2025 Julio González Gil <packages@juliogonzalez.es> 2.0.5-0
+- 2.0.5 from https://github.com/tds-fdw/tds_fdw
+
 * Mon Oct 31 2022 Julio Gonzalez Gil <packages@juliogonzalez.es> 2.0.3-0
 - 2.0.3 from https://github.com/tds-fdw/tds_fdw
 

--- a/SPECS/tds_fdw-13.spec
+++ b/SPECS/tds_fdw-13.spec
@@ -56,7 +56,7 @@ mv %{buildroot}%{PG_DOC}/README.tds_fdw.md %{buildroot}%{MOD_DOC}/README.md
 %attr(755, root, root)%{PG_LIB}/tds_fdw.so
 %dir %attr(755, root, root)%{PG_DATA}
 %dir %attr(755, root, root)%{PG_DATA}/extension
-%attr(644, root, root)%{PG_DATA}/extension/tds_fdw--%{version}.sql
+%attr(644, root, root)%{PG_DATA}/extension/tds_fdw-*.sql
 %attr(644, root, root)%{PG_DATA}/extension/tds_fdw.control
 %dir %attr(755, root, root)%{MOD_DOC}
 %doc %{MOD_DOC}/README.md

--- a/SPECS/tds_fdw-13.spec
+++ b/SPECS/tds_fdw-13.spec
@@ -2,8 +2,8 @@
 %define PG_SVER 13
 
 Name:           postgresql-%{PG_SVER}-tds_fdw
-Version:        2.0.3
-Release:        1%{?dist}
+Version:        2.0.5
+Release:        0%{?dist}
 Summary:        TDS foreing data wrapper for PostgreSQL %{PG_VER}
 License:        None
 URL:            https://github.com/tds-fdw/tds_fdw
@@ -68,7 +68,8 @@ mv %{buildroot}%{PG_DOC}/README.tds_fdw.md %{buildroot}%{MOD_DOC}/README.md
 %endif
 
 %changelog
-* Thu Oct 16 2025 Julio González Gil <packages@juliogonzalez.es> 2.0.3-1
+* Thu Oct 16 2025 Julio González Gil <packages@juliogonzalez.es> 2.0.5-0
+- 2.0.5 from https://github.com/tds-fdw/tds_fdw
 - Fix build openSUSE
 
 * Mon Oct 31 2022 Julio Gonzalez Gil <packages@juliogonzalez.es> 2.0.3-0

--- a/SPECS/tds_fdw-13.spec
+++ b/SPECS/tds_fdw-13.spec
@@ -3,7 +3,7 @@
 
 Name:           postgresql-%{PG_SVER}-tds_fdw
 Version:        2.0.3
-Release:        0%{?dist}
+Release:        1%{?dist}
 Summary:        TDS foreing data wrapper for PostgreSQL %{PG_VER}
 License:        None
 URL:            https://github.com/tds-fdw/tds_fdw
@@ -21,30 +21,15 @@ Requires:       freetds >= 0.91
 BuildRequires:  gcc
 BuildRequires:  freetds-devel
 BuildRequires:  make
-%if 0%{?suse_version}
-BuildRequires:  postgresql%{PG_SVER}-server-devel
-%else
 BuildRequires:  postgresql%{PG_SVER}-devel
-%endif
 
-%if 0%{?suse_version}
-  %define PG_BIN %{_prefix}/lib/postgresql%{PG_SVER}/bin
-  %define PG_LIB %{_prefix}/lib/postgresql%{PG_SVER}/%{_lib}
-  %define PG_DATA %{_datadir}/postgresql%{PG_SVER}
-  %define PG_DOC  %{_docdir}/postgresql%{PG_SVER}/extension
-  %define MOD_DOC %{_docdir}/%{name}
-  %if 0%{?suse_version} >= 1500
-  %define PG_BITCODEDIR %{_prefix}/lib/postgresql%{PG_SVER}/%{_lib}/bitcode
-  %endif
-%else
-  %define PG_BIN %{_prefix}/pgsql-%{PG_VER}/bin
-  %define PG_LIB %{_prefix}/pgsql-%{PG_VER}/lib
-  %define PG_DATA %{_prefix}/pgsql-%{PG_VER}/share
-  %define PG_DOC %{_prefix}/pgsql-%{PG_VER}/doc/extension
-  %define MOD_DOC  %{_docdir}/%{name}
-  %if 0%{?rhel} >= 7
-    %define PG_BITCODEDIR /usr/pgsql-%{PG_VER}/lib/bitcode/
-  %endif
+%define PG_BIN %{_prefix}/pgsql-%{PG_VER}/bin
+%define PG_LIB %{_prefix}/pgsql-%{PG_VER}/lib
+%define PG_DATA %{_prefix}/pgsql-%{PG_VER}/share
+%define PG_DOC %{_prefix}/pgsql-%{PG_VER}/doc/extension
+%define MOD_DOC  %{_docdir}/%{name}
+%if 0%{?rhel} >= 7 || 0%{?suse_version} >= 1500
+  %define PG_BITCODEDIR /usr/pgsql-%{PG_VER}/lib/bitcode/
 %endif
 
 %description
@@ -83,6 +68,9 @@ mv %{buildroot}%{PG_DOC}/README.tds_fdw.md %{buildroot}%{MOD_DOC}/README.md
 %endif
 
 %changelog
+* Thu Oct 16 2025 Julio González Gil <packages@juliogonzalez.es> 2.0.3-1
+- Fix build openSUSE
+
 * Mon Oct 31 2022 Julio Gonzalez Gil <packages@juliogonzalez.es> 2.0.3-0
 - 2.0.3 from https://github.com/tds-fdw/tds_fdw
 

--- a/SPECS/tds_fdw-14.spec
+++ b/SPECS/tds_fdw-14.spec
@@ -3,7 +3,7 @@
 
 Name:           postgresql-%{PG_SVER}-tds_fdw
 Version:        2.0.5
-Release:        0{?dist}
+Release:        0%{?dist}
 Summary:        TDS foreing data wrapper for PostgreSQL %{PG_VER}
 License:        None
 URL:            https://github.com/tds-fdw/tds_fdw
@@ -56,7 +56,7 @@ mv %{buildroot}%{PG_DOC}/README.tds_fdw.md %{buildroot}%{MOD_DOC}/README.md
 %attr(755, root, root)%{PG_LIB}/tds_fdw.so
 %dir %attr(755, root, root)%{PG_DATA}
 %dir %attr(755, root, root)%{PG_DATA}/extension
-%attr(644, root, root)%{PG_DATA}/extension/tds_fdw--%{version}.sql
+%attr(644, root, root)%{PG_DATA}/extension/tds_fdw-*.sql
 %attr(644, root, root)%{PG_DATA}/extension/tds_fdw.control
 %dir %attr(755, root, root)%{MOD_DOC}
 %doc %{MOD_DOC}/README.md

--- a/SPECS/tds_fdw-14.spec
+++ b/SPECS/tds_fdw-14.spec
@@ -3,7 +3,7 @@
 
 Name:           postgresql-%{PG_SVER}-tds_fdw
 Version:        2.0.3
-Release:        0%{?dist}
+Release:        1%{?dist}
 Summary:        TDS foreing data wrapper for PostgreSQL %{PG_VER}
 License:        None
 URL:            https://github.com/tds-fdw/tds_fdw
@@ -21,30 +21,15 @@ Requires:       freetds >= 0.91
 BuildRequires:  gcc
 BuildRequires:  freetds-devel
 BuildRequires:  make
-%if 0%{?suse_version}
-BuildRequires:  postgresql%{PG_SVER}-server-devel
-%else
 BuildRequires:  postgresql%{PG_SVER}-devel
-%endif
 
-%if 0%{?suse_version}
-  %define PG_BIN %{_prefix}/lib/postgresql%{PG_SVER}/bin
-  %define PG_LIB %{_prefix}/lib/postgresql%{PG_SVER}/%{_lib}
-  %define PG_DATA %{_datadir}/postgresql%{PG_SVER}
-  %define PG_DOC  %{_docdir}/postgresql%{PG_SVER}/extension
-  %define MOD_DOC %{_docdir}/%{name}
-  %if 0%{?suse_version} >= 1500
-  %define PG_BITCODEDIR %{_prefix}/lib/postgresql%{PG_SVER}/%{_lib}/bitcode
-  %endif
-%else
-  %define PG_BIN %{_prefix}/pgsql-%{PG_VER}/bin
-  %define PG_LIB %{_prefix}/pgsql-%{PG_VER}/lib
-  %define PG_DATA %{_prefix}/pgsql-%{PG_VER}/share
-  %define PG_DOC %{_prefix}/pgsql-%{PG_VER}/doc/extension
-  %define MOD_DOC  %{_docdir}/%{name}
-  %if 0%{?rhel} >= 7
-    %define PG_BITCODEDIR /usr/pgsql-%{PG_VER}/lib/bitcode/
-  %endif
+%define PG_BIN %{_prefix}/pgsql-%{PG_VER}/bin
+%define PG_LIB %{_prefix}/pgsql-%{PG_VER}/lib
+%define PG_DATA %{_prefix}/pgsql-%{PG_VER}/share
+%define PG_DOC %{_prefix}/pgsql-%{PG_VER}/doc/extension
+%define MOD_DOC  %{_docdir}/%{name}
+%if 0%{?rhel} >= 7 || 0%{?suse_version} >= 1500
+  %define PG_BITCODEDIR /usr/pgsql-%{PG_VER}/lib/bitcode/
 %endif
 
 %description
@@ -83,6 +68,9 @@ mv %{buildroot}%{PG_DOC}/README.tds_fdw.md %{buildroot}%{MOD_DOC}/README.md
 %endif
 
 %changelog
+* Thu Oct 16 2025 Julio González Gil <packages@juliogonzalez.es> 2.0.3-1
+- Fix build openSUSE
+
 * Mon Oct 31 2022 Julio Gonzalez Gil <packages@juliogonzalez.es> 2.0.3-0
 - 2.0.3 from https://github.com/tds-fdw/tds_fdw
 

--- a/SPECS/tds_fdw-14.spec
+++ b/SPECS/tds_fdw-14.spec
@@ -2,8 +2,8 @@
 %define PG_SVER 14
 
 Name:           postgresql-%{PG_SVER}-tds_fdw
-Version:        2.0.3
-Release:        1%{?dist}
+Version:        2.0.5
+Release:        0{?dist}
 Summary:        TDS foreing data wrapper for PostgreSQL %{PG_VER}
 License:        None
 URL:            https://github.com/tds-fdw/tds_fdw
@@ -68,7 +68,8 @@ mv %{buildroot}%{PG_DOC}/README.tds_fdw.md %{buildroot}%{MOD_DOC}/README.md
 %endif
 
 %changelog
-* Thu Oct 16 2025 Julio González Gil <packages@juliogonzalez.es> 2.0.3-1
+* Thu Oct 16 2025 Julio González Gil <packages@juliogonzalez.es> 2.0.5-0
+- 2.0.5 from https://github.com/tds-fdw/tds_fdw
 - Fix build openSUSE
 
 * Mon Oct 31 2022 Julio Gonzalez Gil <packages@juliogonzalez.es> 2.0.3-0

--- a/SPECS/tds_fdw-15.spec
+++ b/SPECS/tds_fdw-15.spec
@@ -56,7 +56,7 @@ mv %{buildroot}%{PG_DOC}/README.tds_fdw.md %{buildroot}%{MOD_DOC}/README.md
 %attr(755, root, root)%{PG_LIB}/tds_fdw.so
 %dir %attr(755, root, root)%{PG_DATA}
 %dir %attr(755, root, root)%{PG_DATA}/extension
-%attr(644, root, root)%{PG_DATA}/extension/tds_fdw--%{version}.sql
+%attr(644, root, root)%{PG_DATA}/extension/tds_fdw-*.sql
 %attr(644, root, root)%{PG_DATA}/extension/tds_fdw.control
 %dir %attr(755, root, root)%{MOD_DOC}
 %doc %{MOD_DOC}/README.md

--- a/SPECS/tds_fdw-15.spec
+++ b/SPECS/tds_fdw-15.spec
@@ -2,8 +2,8 @@
 %define PG_SVER 15
 
 Name:           postgresql-%{PG_SVER}-tds_fdw
-Version:        2.0.3
-Release:        1%{?dist}
+Version:        2.0.5
+Release:        0%{?dist}
 Summary:        TDS foreing data wrapper for PostgreSQL %{PG_VER}
 License:        None
 URL:            https://github.com/tds-fdw/tds_fdw
@@ -68,7 +68,8 @@ mv %{buildroot}%{PG_DOC}/README.tds_fdw.md %{buildroot}%{MOD_DOC}/README.md
 %endif
 
 %changelog
-* Thu Oct 16 2025 Julio González Gil <packages@juliogonzalez.es> 2.0.3-1
+* Thu Oct 16 2025 Julio González Gil <packages@juliogonzalez.es> 2.0.5-0
+- 2.0.5 from https://github.com/tds-fdw/tds_fdw
 - Fix build openSUSE
 
 * Mon Oct 31 2022 Julio Gonzalez Gil <packages@juliogonzalez.es> 2.0.3-0

--- a/SPECS/tds_fdw-15.spec
+++ b/SPECS/tds_fdw-15.spec
@@ -3,7 +3,7 @@
 
 Name:           postgresql-%{PG_SVER}-tds_fdw
 Version:        2.0.3
-Release:        0%{?dist}
+Release:        1%{?dist}
 Summary:        TDS foreing data wrapper for PostgreSQL %{PG_VER}
 License:        None
 URL:            https://github.com/tds-fdw/tds_fdw
@@ -21,30 +21,15 @@ Requires:       freetds >= 0.91
 BuildRequires:  gcc
 BuildRequires:  freetds-devel
 BuildRequires:  make
-%if 0%{?suse_version}
-BuildRequires:  postgresql%{PG_SVER}-server-devel
-%else
 BuildRequires:  postgresql%{PG_SVER}-devel
-%endif
 
-%if 0%{?suse_version}
-  %define PG_BIN %{_prefix}/lib/postgresql%{PG_SVER}/bin
-  %define PG_LIB %{_prefix}/lib/postgresql%{PG_SVER}/%{_lib}
-  %define PG_DATA %{_datadir}/postgresql%{PG_SVER}
-  %define PG_DOC  %{_docdir}/postgresql%{PG_SVER}/extension
-  %define MOD_DOC %{_docdir}/%{name}
-  %if 0%{?suse_version} >= 1500
-  %define PG_BITCODEDIR %{_prefix}/lib/postgresql%{PG_SVER}/%{_lib}/bitcode
-  %endif
-%else
-  %define PG_BIN %{_prefix}/pgsql-%{PG_VER}/bin
-  %define PG_LIB %{_prefix}/pgsql-%{PG_VER}/lib
-  %define PG_DATA %{_prefix}/pgsql-%{PG_VER}/share
-  %define PG_DOC %{_prefix}/pgsql-%{PG_VER}/doc/extension
-  %define MOD_DOC  %{_docdir}/%{name}
-  %if 0%{?rhel} >= 7
-    %define PG_BITCODEDIR /usr/pgsql-%{PG_VER}/lib/bitcode/
-  %endif
+%define PG_BIN %{_prefix}/pgsql-%{PG_VER}/bin
+%define PG_LIB %{_prefix}/pgsql-%{PG_VER}/lib
+%define PG_DATA %{_prefix}/pgsql-%{PG_VER}/share
+%define PG_DOC %{_prefix}/pgsql-%{PG_VER}/doc/extension
+%define MOD_DOC  %{_docdir}/%{name}
+%if 0%{?rhel} >= 7 || 0%{?suse_version} >= 1500
+  %define PG_BITCODEDIR /usr/pgsql-%{PG_VER}/lib/bitcode/
 %endif
 
 %description
@@ -83,6 +68,9 @@ mv %{buildroot}%{PG_DOC}/README.tds_fdw.md %{buildroot}%{MOD_DOC}/README.md
 %endif
 
 %changelog
+* Thu Oct 16 2025 Julio González Gil <packages@juliogonzalez.es> 2.0.3-1
+- Fix build openSUSE
+
 * Mon Oct 31 2022 Julio Gonzalez Gil <packages@juliogonzalez.es> 2.0.3-0
 - 2.0.3 from https://github.com/tds-fdw/tds_fdw
 

--- a/SPECS/tds_fdw-16.spec
+++ b/SPECS/tds_fdw-16.spec
@@ -56,7 +56,7 @@ mv %{buildroot}%{PG_DOC}/README.tds_fdw.md %{buildroot}%{MOD_DOC}/README.md
 %attr(755, root, root)%{PG_LIB}/tds_fdw.so
 %dir %attr(755, root, root)%{PG_DATA}
 %dir %attr(755, root, root)%{PG_DATA}/extension
-%attr(644, root, root)%{PG_DATA}/extension/tds_fdw--%{version}.sql
+%attr(644, root, root)%{PG_DATA}/extension/tds_fdw-*.sql
 %attr(644, root, root)%{PG_DATA}/extension/tds_fdw.control
 %dir %attr(755, root, root)%{MOD_DOC}
 %doc %{MOD_DOC}/README.md

--- a/SPECS/tds_fdw-16.spec
+++ b/SPECS/tds_fdw-16.spec
@@ -3,7 +3,7 @@
 
 Name:           postgresql-%{PG_SVER}-tds_fdw
 Version:        2.0.3
-Release:        1%{?dist}
+Release:        0%{?dist}
 Summary:        TDS foreing data wrapper for PostgreSQL %{PG_VER}
 License:        None
 URL:            https://github.com/tds-fdw/tds_fdw
@@ -68,8 +68,9 @@ mv %{buildroot}%{PG_DOC}/README.tds_fdw.md %{buildroot}%{MOD_DOC}/README.md
 %endif
 
 %changelog
-* Thu Oct 16 2025 Julio González Gil <packages@juliogonzalez.es> 2.0.3-1
+* Thu Oct 16 2025 Julio González Gil <packages@juliogonzalez.es> 2.0.5-0
+- 2.0.5 from https://github.com/tds-fdw/tds_fdw
 - Fix build openSUSE
 
 * Fri Dec 22 2023 Julio González Gil <packages@juliogonzalez.es> 2.0.3-0
-- 2.0.3 from https://github.com/tds-fdw/tds_fdw
+- 2.0.4 from https://github.com/tds-fdw/tds_fdw

--- a/SPECS/tds_fdw-16.spec
+++ b/SPECS/tds_fdw-16.spec
@@ -3,7 +3,7 @@
 
 Name:           postgresql-%{PG_SVER}-tds_fdw
 Version:        2.0.3
-Release:        0%{?dist}
+Release:        1%{?dist}
 Summary:        TDS foreing data wrapper for PostgreSQL %{PG_VER}
 License:        None
 URL:            https://github.com/tds-fdw/tds_fdw
@@ -21,30 +21,15 @@ Requires:       freetds >= 0.91
 BuildRequires:  gcc
 BuildRequires:  freetds-devel
 BuildRequires:  make
-%if 0%{?suse_version}
-BuildRequires:  postgresql%{PG_SVER}-server-devel
-%else
 BuildRequires:  postgresql%{PG_SVER}-devel
-%endif
 
-%if 0%{?suse_version}
-  %define PG_BIN %{_prefix}/lib/postgresql%{PG_SVER}/bin
-  %define PG_LIB %{_prefix}/lib/postgresql%{PG_SVER}/%{_lib}
-  %define PG_DATA %{_datadir}/postgresql%{PG_SVER}
-  %define PG_DOC  %{_docdir}/postgresql%{PG_SVER}/extension
-  %define MOD_DOC %{_docdir}/%{name}
-  %if 0%{?suse_version} >= 1500
-  %define PG_BITCODEDIR %{_prefix}/lib/postgresql%{PG_SVER}/%{_lib}/bitcode
-  %endif
-%else
-  %define PG_BIN %{_prefix}/pgsql-%{PG_VER}/bin
-  %define PG_LIB %{_prefix}/pgsql-%{PG_VER}/lib
-  %define PG_DATA %{_prefix}/pgsql-%{PG_VER}/share
-  %define PG_DOC %{_prefix}/pgsql-%{PG_VER}/doc/extension
-  %define MOD_DOC  %{_docdir}/%{name}
-  %if 0%{?rhel} >= 7
-    %define PG_BITCODEDIR /usr/pgsql-%{PG_VER}/lib/bitcode/
-  %endif
+%define PG_BIN %{_prefix}/pgsql-%{PG_VER}/bin
+%define PG_LIB %{_prefix}/pgsql-%{PG_VER}/lib
+%define PG_DATA %{_prefix}/pgsql-%{PG_VER}/share
+%define PG_DOC %{_prefix}/pgsql-%{PG_VER}/doc/extension
+%define MOD_DOC  %{_docdir}/%{name}
+%if 0%{?rhel} >= 7 || 0%{?suse_version} >= 1500
+  %define PG_BITCODEDIR /usr/pgsql-%{PG_VER}/lib/bitcode/
 %endif
 
 %description
@@ -83,5 +68,8 @@ mv %{buildroot}%{PG_DOC}/README.tds_fdw.md %{buildroot}%{MOD_DOC}/README.md
 %endif
 
 %changelog
+* Thu Oct 16 2025 Julio González Gil <packages@juliogonzalez.es> 2.0.3-1
+- Fix build openSUSE
+
 * Fri Dec 22 2023 Julio González Gil <packages@juliogonzalez.es> 2.0.3-0
 - 2.0.3 from https://github.com/tds-fdw/tds_fdw

--- a/SPECS/tds_fdw-17.spec
+++ b/SPECS/tds_fdw-17.spec
@@ -56,7 +56,7 @@ mv %{buildroot}%{PG_DOC}/README.tds_fdw.md %{buildroot}%{MOD_DOC}/README.md
 %attr(755, root, root)%{PG_LIB}/tds_fdw.so
 %dir %attr(755, root, root)%{PG_DATA}
 %dir %attr(755, root, root)%{PG_DATA}/extension
-%attr(644, root, root)%{PG_DATA}/extension/tds_fdw--%{version}.sql
+%attr(644, root, root)%{PG_DATA}/extension/tds_fdw-*.sql
 %attr(644, root, root)%{PG_DATA}/extension/tds_fdw.control
 %dir %attr(755, root, root)%{MOD_DOC}
 %doc %{MOD_DOC}/README.md

--- a/SPECS/tds_fdw-17.spec
+++ b/SPECS/tds_fdw-17.spec
@@ -2,7 +2,7 @@
 %define PG_SVER 17
 
 Name:           postgresql-%{PG_SVER}-tds_fdw
-Version:        2.0.3
+Version:        2.0.5
 Release:        0%{?dist}
 Summary:        TDS foreing data wrapper for PostgreSQL %{PG_VER}
 License:        None
@@ -68,5 +68,5 @@ mv %{buildroot}%{PG_DOC}/README.tds_fdw.md %{buildroot}%{MOD_DOC}/README.md
 %endif
 
 %changelog
-* Thu Oct 16 2025 Julio González Gil <packages@juliogonzalez.es> 2.0.3-0
+* Thu Oct 16 2025 Julio González Gil <packages@juliogonzalez.es> 2.0.5-0
 - 2.0.3 from https://github.com/tds-fdw/tds_fdw

--- a/SPECS/tds_fdw-17.spec
+++ b/SPECS/tds_fdw-17.spec
@@ -22,26 +22,14 @@ BuildRequires:  gcc
 BuildRequires:  freetds-devel
 BuildRequires:  make
 BuildRequires:  postgresql%{PG_SVER}-devel
-%endif
 
-%if 0%{?suse_version}
-  %define PG_BIN %{_prefix}/lib/postgresql%{PG_SVER}/bin
-  %define PG_LIB %{_prefix}/lib/postgresql%{PG_SVER}/%{_lib}
-  %define PG_DATA %{_datadir}/postgresql%{PG_SVER}
-  %define PG_DOC  %{_docdir}/postgresql%{PG_SVER}/extension
-  %define MOD_DOC %{_docdir}/%{name}
-  %if 0%{?suse_version} >= 1500
-  %define PG_BITCODEDIR %{_prefix}/lib/postgresql%{PG_SVER}/%{_lib}/bitcode
-  %endif
-%else
-  %define PG_BIN %{_prefix}/pgsql-%{PG_VER}/bin
-  %define PG_LIB %{_prefix}/pgsql-%{PG_VER}/lib
-  %define PG_DATA %{_prefix}/pgsql-%{PG_VER}/share
-  %define PG_DOC %{_prefix}/pgsql-%{PG_VER}/doc/extension
-  %define MOD_DOC  %{_docdir}/%{name}
-  %if 0%{?rhel} >= 7
-    %define PG_BITCODEDIR /usr/pgsql-%{PG_VER}/lib/bitcode/
-  %endif
+%define PG_BIN %{_prefix}/pgsql-%{PG_VER}/bin
+%define PG_LIB %{_prefix}/pgsql-%{PG_VER}/lib
+%define PG_DATA %{_prefix}/pgsql-%{PG_VER}/share
+%define PG_DOC %{_prefix}/pgsql-%{PG_VER}/doc/extension
+%define MOD_DOC  %{_docdir}/%{name}
+%if 0%{?rhel} >= 7 || 0%{?suse_version} >= 1500
+  %define PG_BITCODEDIR /usr/pgsql-%{PG_VER}/lib/bitcode/
 %endif
 
 %description

--- a/SPECS/tds_fdw-17.spec
+++ b/SPECS/tds_fdw-17.spec
@@ -1,0 +1,84 @@
+%define PG_VER 17
+%define PG_SVER 17
+
+Name:           postgresql-%{PG_SVER}-tds_fdw
+Version:        2.0.3
+Release:        0%{?dist}
+Summary:        TDS foreing data wrapper for PostgreSQL %{PG_VER}
+License:        None
+URL:            https://github.com/tds-fdw/tds_fdw
+Source:         https://github.com/tds-fdw/tds_fdw/archive/v%{version}.tar.gz
+
+Provides:       tds_fdw%{PG_SVER}
+
+Requires:       postgresql%{PG_SVER} >= %{PG_VER}.0
+Requires:       postgresql%{PG_SVER}-server >= %{PG_VER}.0
+%if ! 0%{?suse_version}
+Requires:       postgresql%{PG_SVER}-libs >= %{PG_VER}.0
+%endif
+Requires:       freetds >= 0.91
+
+BuildRequires:  gcc
+BuildRequires:  freetds-devel
+BuildRequires:  make
+BuildRequires:  postgresql%{PG_SVER}-devel
+%endif
+
+%if 0%{?suse_version}
+  %define PG_BIN %{_prefix}/lib/postgresql%{PG_SVER}/bin
+  %define PG_LIB %{_prefix}/lib/postgresql%{PG_SVER}/%{_lib}
+  %define PG_DATA %{_datadir}/postgresql%{PG_SVER}
+  %define PG_DOC  %{_docdir}/postgresql%{PG_SVER}/extension
+  %define MOD_DOC %{_docdir}/%{name}
+  %if 0%{?suse_version} >= 1500
+  %define PG_BITCODEDIR %{_prefix}/lib/postgresql%{PG_SVER}/%{_lib}/bitcode
+  %endif
+%else
+  %define PG_BIN %{_prefix}/pgsql-%{PG_VER}/bin
+  %define PG_LIB %{_prefix}/pgsql-%{PG_VER}/lib
+  %define PG_DATA %{_prefix}/pgsql-%{PG_VER}/share
+  %define PG_DOC %{_prefix}/pgsql-%{PG_VER}/doc/extension
+  %define MOD_DOC  %{_docdir}/%{name}
+  %if 0%{?rhel} >= 7
+    %define PG_BITCODEDIR /usr/pgsql-%{PG_VER}/lib/bitcode/
+  %endif
+%endif
+
+%description
+This is a PostgreSQL foreign data wrapper that can connect to databases that
+use the Tabular Data Stream (TDS) protocol, such as Sybase databases and
+Microsoft SQL server.
+.
+It does not yet support write operations, as added in PostgreSQL %{PG_VER}.
+
+%global debug_package %{nil}
+
+%prep
+%setup -q -n tds_fdw-%{version}
+
+%build
+PATH=%{PG_BIN}/:$PATH make USE_PGXS=1
+
+%install
+PATH=%{PG_BIN}/:$PATH make USE_PGXS=1 install DESTDIR=%{buildroot}
+mkdir -p %{buildroot}%{MOD_DOC}
+mv %{buildroot}%{PG_DOC}/README.tds_fdw.md %{buildroot}%{MOD_DOC}/README.md
+
+%files
+%attr(755, root, root)%{PG_LIB}/tds_fdw.so
+%dir %attr(755, root, root)%{PG_DATA}
+%dir %attr(755, root, root)%{PG_DATA}/extension
+%attr(644, root, root)%{PG_DATA}/extension/tds_fdw--%{version}.sql
+%attr(644, root, root)%{PG_DATA}/extension/tds_fdw.control
+%dir %attr(755, root, root)%{MOD_DOC}
+%doc %{MOD_DOC}/README.md
+%if 0%{?rhel} >= 7 || 0%{?suse_version} >= 1500
+%attr(644, root, root)%{PG_BITCODEDIR}/tds_fdw.index.bc
+%attr(644, root, root)%{PG_BITCODEDIR}/tds_fdw/src/deparse.bc
+%attr(644, root, root)%{PG_BITCODEDIR}/tds_fdw/src/options.bc
+%attr(644, root, root)%{PG_BITCODEDIR}/tds_fdw/src/tds_fdw.bc
+%endif
+
+%changelog
+* Thu Oct 16 2025 Julio González Gil <packages@juliogonzalez.es> 2.0.3-0
+- 2.0.3 from https://github.com/tds-fdw/tds_fdw

--- a/SPECS/tds_fdw-18.spec
+++ b/SPECS/tds_fdw-18.spec
@@ -56,7 +56,7 @@ mv %{buildroot}%{PG_DOC}/README.tds_fdw.md %{buildroot}%{MOD_DOC}/README.md
 %attr(755, root, root)%{PG_LIB}/tds_fdw.so
 %dir %attr(755, root, root)%{PG_DATA}
 %dir %attr(755, root, root)%{PG_DATA}/extension
-%attr(644, root, root)%{PG_DATA}/extension/tds_fdw--%{version}.sql
+%attr(644, root, root)%{PG_DATA}/extension/tds_fdw-*.sql
 %attr(644, root, root)%{PG_DATA}/extension/tds_fdw.control
 %dir %attr(755, root, root)%{MOD_DOC}
 %doc %{MOD_DOC}/README.md

--- a/SPECS/tds_fdw-18.spec
+++ b/SPECS/tds_fdw-18.spec
@@ -22,26 +22,14 @@ BuildRequires:  gcc
 BuildRequires:  freetds-devel
 BuildRequires:  make
 BuildRequires:  postgresql%{PG_SVER}-devel
-%endif
 
-%if 0%{?suse_version}
-  %define PG_BIN %{_prefix}/lib/postgresql%{PG_SVER}/bin
-  %define PG_LIB %{_prefix}/lib/postgresql%{PG_SVER}/%{_lib}
-  %define PG_DATA %{_datadir}/postgresql%{PG_SVER}
-  %define PG_DOC  %{_docdir}/postgresql%{PG_SVER}/extension
-  %define MOD_DOC %{_docdir}/%{name}
-  %if 0%{?suse_version} >= 1500
-  %define PG_BITCODEDIR %{_prefix}/lib/postgresql%{PG_SVER}/%{_lib}/bitcode
-  %endif
-%else
-  %define PG_BIN %{_prefix}/pgsql-%{PG_VER}/bin
-  %define PG_LIB %{_prefix}/pgsql-%{PG_VER}/lib
-  %define PG_DATA %{_prefix}/pgsql-%{PG_VER}/share
-  %define PG_DOC %{_prefix}/pgsql-%{PG_VER}/doc/extension
-  %define MOD_DOC  %{_docdir}/%{name}
-  %if 0%{?rhel} >= 7
-    %define PG_BITCODEDIR /usr/pgsql-%{PG_VER}/lib/bitcode/
-  %endif
+%define PG_BIN %{_prefix}/pgsql-%{PG_VER}/bin
+%define PG_LIB %{_prefix}/pgsql-%{PG_VER}/lib
+%define PG_DATA %{_prefix}/pgsql-%{PG_VER}/share
+%define PG_DOC %{_prefix}/pgsql-%{PG_VER}/doc/extension
+%define MOD_DOC  %{_docdir}/%{name}
+%if 0%{?rhel} >= 7 || 0%{?suse_version} >= 1500
+  %define PG_BITCODEDIR /usr/pgsql-%{PG_VER}/lib/bitcode/
 %endif
 
 %description

--- a/SPECS/tds_fdw-18.spec
+++ b/SPECS/tds_fdw-18.spec
@@ -2,7 +2,7 @@
 %define PG_SVER 18
 
 Name:           postgresql-%{PG_SVER}-tds_fdw
-Version:        2.0.3
+Version:        2.0.5
 Release:        0%{?dist}
 Summary:        TDS foreing data wrapper for PostgreSQL %{PG_VER}
 License:        None
@@ -68,5 +68,5 @@ mv %{buildroot}%{PG_DOC}/README.tds_fdw.md %{buildroot}%{MOD_DOC}/README.md
 %endif
 
 %changelog
-* Thu Oct 16 2025 Julio González Gil <packages@juliogonzalez.es> 2.0.3-0
+* Thu Oct 16 2025 Julio González Gil <packages@juliogonzalez.es> 2.0.5-0
 - 2.0.3 from https://github.com/tds-fdw/tds_fdw

--- a/SPECS/tds_fdw-18.spec
+++ b/SPECS/tds_fdw-18.spec
@@ -1,0 +1,84 @@
+%define PG_VER 18
+%define PG_SVER 18
+
+Name:           postgresql-%{PG_SVER}-tds_fdw
+Version:        2.0.3
+Release:        0%{?dist}
+Summary:        TDS foreing data wrapper for PostgreSQL %{PG_VER}
+License:        None
+URL:            https://github.com/tds-fdw/tds_fdw
+Source:         https://github.com/tds-fdw/tds_fdw/archive/v%{version}.tar.gz
+
+Provides:       tds_fdw%{PG_SVER}
+
+Requires:       postgresql%{PG_SVER} >= %{PG_VER}.0
+Requires:       postgresql%{PG_SVER}-server >= %{PG_VER}.0
+%if ! 0%{?suse_version}
+Requires:       postgresql%{PG_SVER}-libs >= %{PG_VER}.0
+%endif
+Requires:       freetds >= 0.91
+
+BuildRequires:  gcc
+BuildRequires:  freetds-devel
+BuildRequires:  make
+BuildRequires:  postgresql%{PG_SVER}-devel
+%endif
+
+%if 0%{?suse_version}
+  %define PG_BIN %{_prefix}/lib/postgresql%{PG_SVER}/bin
+  %define PG_LIB %{_prefix}/lib/postgresql%{PG_SVER}/%{_lib}
+  %define PG_DATA %{_datadir}/postgresql%{PG_SVER}
+  %define PG_DOC  %{_docdir}/postgresql%{PG_SVER}/extension
+  %define MOD_DOC %{_docdir}/%{name}
+  %if 0%{?suse_version} >= 1500
+  %define PG_BITCODEDIR %{_prefix}/lib/postgresql%{PG_SVER}/%{_lib}/bitcode
+  %endif
+%else
+  %define PG_BIN %{_prefix}/pgsql-%{PG_VER}/bin
+  %define PG_LIB %{_prefix}/pgsql-%{PG_VER}/lib
+  %define PG_DATA %{_prefix}/pgsql-%{PG_VER}/share
+  %define PG_DOC %{_prefix}/pgsql-%{PG_VER}/doc/extension
+  %define MOD_DOC  %{_docdir}/%{name}
+  %if 0%{?rhel} >= 7
+    %define PG_BITCODEDIR /usr/pgsql-%{PG_VER}/lib/bitcode/
+  %endif
+%endif
+
+%description
+This is a PostgreSQL foreign data wrapper that can connect to databases that
+use the Tabular Data Stream (TDS) protocol, such as Sybase databases and
+Microsoft SQL server.
+.
+It does not yet support write operations, as added in PostgreSQL %{PG_VER}.
+
+%global debug_package %{nil}
+
+%prep
+%setup -q -n tds_fdw-%{version}
+
+%build
+PATH=%{PG_BIN}/:$PATH make USE_PGXS=1
+
+%install
+PATH=%{PG_BIN}/:$PATH make USE_PGXS=1 install DESTDIR=%{buildroot}
+mkdir -p %{buildroot}%{MOD_DOC}
+mv %{buildroot}%{PG_DOC}/README.tds_fdw.md %{buildroot}%{MOD_DOC}/README.md
+
+%files
+%attr(755, root, root)%{PG_LIB}/tds_fdw.so
+%dir %attr(755, root, root)%{PG_DATA}
+%dir %attr(755, root, root)%{PG_DATA}/extension
+%attr(644, root, root)%{PG_DATA}/extension/tds_fdw--%{version}.sql
+%attr(644, root, root)%{PG_DATA}/extension/tds_fdw.control
+%dir %attr(755, root, root)%{MOD_DOC}
+%doc %{MOD_DOC}/README.md
+%if 0%{?rhel} >= 7 || 0%{?suse_version} >= 1500
+%attr(644, root, root)%{PG_BITCODEDIR}/tds_fdw.index.bc
+%attr(644, root, root)%{PG_BITCODEDIR}/tds_fdw/src/deparse.bc
+%attr(644, root, root)%{PG_BITCODEDIR}/tds_fdw/src/options.bc
+%attr(644, root, root)%{PG_BITCODEDIR}/tds_fdw/src/tds_fdw.bc
+%endif
+
+%changelog
+* Thu Oct 16 2025 Julio González Gil <packages@juliogonzalez.es> 2.0.3-0
+- 2.0.3 from https://github.com/tds-fdw/tds_fdw

--- a/SPECS/tds_fdw-93.spec
+++ b/SPECS/tds_fdw-93.spec
@@ -2,7 +2,7 @@
 %define PG_SVER 93
 
 Name:           postgresql-%{PG_SVER}-tds_fdw
-Version:        2.0.3
+Version:        2.0.5
 Release:        0%{?dist}
 Summary:        TDS foreing data wrapper for PostgreSQL %{PG_VER}
 License:        None
@@ -67,6 +67,9 @@ mv %{buildroot}%{PG_DOC}/README.tds_fdw.md %{buildroot}%{MOD_DOC}/README.md
 %doc %{MOD_DOC}/README.md
 
 %changelog
+* Thu Oct 16 2025 Julio González Gil <packages@juliogonzalez.es> 2.0.5-0
+- 2.0.5 from https://github.com/tds-fdw/tds_fdw
+
 * Mon Oct 31 2022 Julio Gonzalez Gil <packages@juliogonzalez.es> 2.0.3-0
 - 2.0.3 from https://github.com/tds-fdw/tds_fdw
 

--- a/SPECS/tds_fdw-93.spec
+++ b/SPECS/tds_fdw-93.spec
@@ -61,7 +61,7 @@ mv %{buildroot}%{PG_DOC}/README.tds_fdw.md %{buildroot}%{MOD_DOC}/README.md
 %attr(755, root, root)%{PG_LIB}/tds_fdw.so
 %dir %attr(755, root, root)%{PG_DATA}
 %dir %attr(755, root, root)%{PG_DATA}/extension
-%attr(644, root, root)%{PG_DATA}/extension/tds_fdw--%{version}.sql
+%attr(644, root, root)%{PG_DATA}/extension/tds_fdw-*.sql
 %attr(644, root, root)%{PG_DATA}/extension/tds_fdw.control
 %dir %attr(755, root, root)%{MOD_DOC}
 %doc %{MOD_DOC}/README.md

--- a/SPECS/tds_fdw-94.spec
+++ b/SPECS/tds_fdw-94.spec
@@ -61,7 +61,7 @@ mv %{buildroot}%{PG_DOC}/README.tds_fdw.md %{buildroot}%{MOD_DOC}/README.md
 %attr(755, root, root)%{PG_LIB}/tds_fdw.so
 %dir %attr(755, root, root)%{PG_DATA}
 %dir %attr(755, root, root)%{PG_DATA}/extension
-%attr(644, root, root)%{PG_DATA}/extension/tds_fdw--%{version}.sql
+%attr(644, root, root)%{PG_DATA}/extension/tds_fdw-*.sql
 %attr(644, root, root)%{PG_DATA}/extension/tds_fdw.control
 %dir %attr(755, root, root)%{MOD_DOC}
 %doc %{MOD_DOC}/README.md

--- a/SPECS/tds_fdw-94.spec
+++ b/SPECS/tds_fdw-94.spec
@@ -2,7 +2,7 @@
 %define PG_SVER 94
 
 Name:           postgresql-%{PG_SVER}-tds_fdw
-Version:        2.0.3
+Version:        2.0.5
 Release:        0%{?dist}
 Summary:        TDS foreing data wrapper for PostgreSQL %{PG_VER}
 License:        None
@@ -67,6 +67,9 @@ mv %{buildroot}%{PG_DOC}/README.tds_fdw.md %{buildroot}%{MOD_DOC}/README.md
 %doc %{MOD_DOC}/README.md
 
 %changelog
+* Thu Oct 16 2025 Julio González Gil <packages@juliogonzalez.es> 2.0.5-0
+- 2.0.5 from https://github.com/tds-fdw/tds_fdw
+
 * Mon Oct 31 2022 Julio Gonzalez Gil <packages@juliogonzalez.es> 2.0.3-0
 - 2.0.3 from https://github.com/tds-fdw/tds_fdw
 

--- a/SPECS/tds_fdw-95.spec
+++ b/SPECS/tds_fdw-95.spec
@@ -2,7 +2,7 @@
 %define PG_SVER 95
 
 Name:           postgresql-%{PG_SVER}-tds_fdw
-Version:        2.0.3
+Version:        2.0.5
 Release:        0%{?dist}
 Summary:        TDS foreing data wrapper for PostgreSQL %{PG_VER}
 License:        None
@@ -67,6 +67,9 @@ mv %{buildroot}%{PG_DOC}/README.tds_fdw.md %{buildroot}%{MOD_DOC}/README.md
 %doc %{MOD_DOC}/README.md
 
 %changelog
+* Thu Oct 16 2025 Julio González Gil <packages@juliogonzalez.es> 2.0.5-0
+- 2.0.5 from https://github.com/tds-fdw/tds_fdw
+
 * Mon Oct 31 2022 Julio Gonzalez Gil <packages@juliogonzalez.es> 2.0.3-0
 - 2.0.3 from https://github.com/tds-fdw/tds_fdw
 

--- a/SPECS/tds_fdw-95.spec
+++ b/SPECS/tds_fdw-95.spec
@@ -61,7 +61,7 @@ mv %{buildroot}%{PG_DOC}/README.tds_fdw.md %{buildroot}%{MOD_DOC}/README.md
 %attr(755, root, root)%{PG_LIB}/tds_fdw.so
 %dir %attr(755, root, root)%{PG_DATA}
 %dir %attr(755, root, root)%{PG_DATA}/extension
-%attr(644, root, root)%{PG_DATA}/extension/tds_fdw--%{version}.sql
+%attr(644, root, root)%{PG_DATA}/extension/tds_fdw-*.sql
 %attr(644, root, root)%{PG_DATA}/extension/tds_fdw.control
 %dir %attr(755, root, root)%{MOD_DOC}
 %doc %{MOD_DOC}/README.md

--- a/SPECS/tds_fdw-96.spec
+++ b/SPECS/tds_fdw-96.spec
@@ -2,7 +2,7 @@
 %define PG_SVER 96
 
 Name:           postgresql-%{PG_SVER}-tds_fdw
-Version:        2.0.3
+Version:        2.0.5
 Release:        0%{?dist}
 Summary:        TDS foreing data wrapper for PostgreSQL %{PG_VER}
 License:        None
@@ -67,6 +67,9 @@ mv %{buildroot}%{PG_DOC}/README.tds_fdw.md %{buildroot}%{MOD_DOC}/README.md
 %doc %{MOD_DOC}/README.md
 
 %changelog
+* Thu Oct 16 2025 Julio González Gil <packages@juliogonzalez.es> 2.0.5-0
+- 2.0.5 from https://github.com/tds-fdw/tds_fdw
+
 * Mon Oct 31 2022 Julio Gonzalez Gil <packages@juliogonzalez.es> 2.0.3-0
 - 2.0.3 from https://github.com/tds-fdw/tds_fdw
 

--- a/SPECS/tds_fdw-96.spec
+++ b/SPECS/tds_fdw-96.spec
@@ -61,7 +61,7 @@ mv %{buildroot}%{PG_DOC}/README.tds_fdw.md %{buildroot}%{MOD_DOC}/README.md
 %attr(755, root, root)%{PG_LIB}/tds_fdw.so
 %dir %attr(755, root, root)%{PG_DATA}
 %dir %attr(755, root, root)%{PG_DATA}/extension
-%attr(644, root, root)%{PG_DATA}/extension/tds_fdw--%{version}.sql
+%attr(644, root, root)%{PG_DATA}/extension/tds_fdw-*.sql
 %attr(644, root, root)%{PG_DATA}/extension/tds_fdw.control
 %dir %attr(755, root, root)%{MOD_DOC}
 %doc %{MOD_DOC}/README.md

--- a/ci
+++ b/ci
@@ -173,7 +173,7 @@ for IGNOREDCOMBINATION in ${IGNOREDCOMBINATIONS}; do
 done
 
 if [ "${CENGINE}" == "podman" ]; then
-  EXTRA_FLAGS="${EXTRA_FLAGS} --userns=keep-id"
+  EXTRA_FLAGS="${EXTRA_FLAGS} --userns=keep-id  --security-opt label=disable"
 fi
 
 # Check name

--- a/ci
+++ b/ci
@@ -9,7 +9,7 @@ SCRIPT=$(basename ${0})
 SUPPORTEDDISTROS='rockylinux8 opensuseleap15.6'
 
 # Supported PostgreSQL major versions
-POSTGRESQLMAJORVERS='9.3 9.4 9.5 9.6 10 11 12 13 14 15 16'
+POSTGRESQLMAJORVERS='9.3 9.4 9.5 9.6 10 11 12 13 14 15 16 17 18'
 
 # Ignored combinations, will exit without errors so the CI does not fail
 IGNOREDCOMBINATIONS="centos7|16"

--- a/tds_fdw-rpm
+++ b/tds_fdw-rpm
@@ -1,7 +1,7 @@
 #!/bin/bash -e
 
 SCRIPT=$(basename ${0})
-VERSIONS="9.3 9.4 9.5 9.6 10 11 12 13 14 15 16"
+VERSIONS="9.3 9.4 9.5 9.6 10 11 12 13 14 15 16 17 18"
 
 function help() {
   echo ""


### PR DESCRIPTION
- Adding PostgreSQL 17 required tds_fdw 2.0.4
- Adding PostgreSQL 18 required tds_fdw 2.0.5
- So we skip 2.0.5 and go directly to 2.0.5

This PR also fixed the build for openSUSE Leap 15.6 and PosgreSQL >= 13, as we don't need different `PG_*` variables anymore.

I did not touch PostgreSQL <= 12 as those versions are EoL by upstream, so hopefully that didn't change.