### PR TITLE
CI: Remove EoL OS, add openSUSE Leap 15.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ tds_fdw
 
 CentOS/RH/Amazon RPMs for tds_fdw  <https://github.com/tds-fdw/tds_fdw> and postgresql 9.3.4 or later
 
-Tested on CentOS 7, Rocky Linux 8 x86_64 and openSUSE Leap 15.5. Should work for other RPM base distributions such as Amazon Linux
+Tested on Rocky Linux 8 x86_64 and openSUSE Leap 15.6. Should work for pretty much any RPM base distributions. Feel free to report problems on the issues, so we can have a look.
 
 tds_fdw is a PostgreSQL foreign data wrapper that can connect to databases that use the Tabular Data Stream (TDS) protocol, such as Sybase databases and Microsoft SQL server.
 

--- a/ci
+++ b/ci
@@ -6,7 +6,7 @@ LANG=en_EN
 SCRIPT=$(basename ${0})
 
 # Supported distributions
-SUPPORTEDDISTROS='centos6 centos7 rockylinux8 opensuseleap15.5'
+SUPPORTEDDISTROS='rockylinux8 opensuseleap15.6'
 
 # Supported PostgreSQL major versions
 POSTGRESQLMAJORVERS='9.3 9.4 9.5 9.6 10 11 12 13 14 15 16'


### PR DESCRIPTION
We don't have images anymore for CentOS6, CentOS, or openSUSE Leap 15.5, so those are removed, and instead openSUSE Leap 15.6

This doesn't mean the `tds_fdw-rpm` script or the SPECS are not going to work with those EoL OS. They should still work just fine, it's simply that we can't test them anymore.